### PR TITLE
Add documentation url to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Authentication
+https://www.atauthentication.com
 
 Modular, strongly typed, promise based, independent implementations of various
 authentication protocols. These libraries don't have a perfectly uniform API and


### PR DESCRIPTION
Hey! I've been enjoying using your packages, and as far as I can tell this project doesn't have any place pointing back to your api docs. 